### PR TITLE
Bug(?) in Coordinator.withdrawMGN...

### DIFF
--- a/trufflescripts/auction.js
+++ b/trufflescripts/auction.js
@@ -463,21 +463,30 @@ async function withdrawUnlockedMagnolia({ ethPool, gnoPool }) {
 async function withdrawFunds({ ethPool, gnoPool, coordinator }, accounts) {
   console.log('\nWithrawing ETH, GNO and MGN from the pools')
 
+  await printPoolState(ethPool)
+
   if (argv.coord || argv.c) {
     console.log('Calling Coordinator.withdrawMGNandDepositsFromBothPools()')
     await Promise.all(accounts.map(acc => coordinator.withdrawMGNandDepositsFromBothPools({ from: acc })))
+
+    await printPoolState(ethPool)
     return
   }
 
-  console.log('Calling Pool.withdrawDeposit() and Pool.withdrawMagnolia() on each pool')
+  console.log('Calling Pool.withdrawDeposit() on each pool')
   await Promise.all(accounts.map(acc => Promise.all([
-      ethPool.withdrawDeposit({ from: acc }),
-      gnoPool.withdrawDeposit({ from: acc }),
-    ])))
+    ethPool.withdrawDeposit({ from: acc }),
+    gnoPool.withdrawDeposit({ from: acc }),
+  ])))
+  
+  await printPoolState(ethPool)
+  console.log('Calling Pool.withdrawMagnolia() on each pool')
   await Promise.all(accounts.map(acc => Promise.all([
       ethPool.withdrawMagnolia({ from: acc }),
       gnoPool.withdrawMagnolia({ from: acc }),
     ])))
+
+  await printPoolState(ethPool)
 }
 
 // const address2symbol = {}

--- a/trufflescripts/auction.js
+++ b/trufflescripts/auction.js
@@ -135,7 +135,7 @@ async function runStep(step, accounts, contracts, master) {
       await participateInAuction(contracts)
       break
     case 4:
-      await fillAndClearAuctions(contracts, (Math.random() / 10 + 0.02).toFixed(3), master)
+      await fillAndClearAuctions(contracts, 0.02, master)
       await printMGNAccumulated(contracts, accounts)
       break
     case 5:

--- a/trufflescripts/auction.js
+++ b/trufflescripts/auction.js
@@ -473,6 +473,8 @@ async function withdrawFunds({ ethPool, gnoPool, coordinator }, accounts) {
   await Promise.all(accounts.map(acc => Promise.all([
       ethPool.withdrawDeposit({ from: acc }),
       gnoPool.withdrawDeposit({ from: acc }),
+    ])))
+  await Promise.all(accounts.map(acc => Promise.all([
       ethPool.withdrawMagnolia({ from: acc }),
       gnoPool.withdrawMagnolia({ from: acc }),
     ])))

--- a/trufflescripts/auction.js
+++ b/trufflescripts/auction.js
@@ -460,9 +460,16 @@ async function withdrawUnlockedMagnolia({ ethPool, gnoPool }) {
   await printPoolState(ethPool)
 }
 
-async function withdrawFunds({ ethPool, gnoPool }, accounts) {
-  console.log('Withrawing ETH, GNO and MGN from the pools')
+async function withdrawFunds({ ethPool, gnoPool, coordinator }, accounts) {
+  console.log('\nWithrawing ETH, GNO and MGN from the pools')
 
+  if (argv.coord || argv.c) {
+    console.log('Calling Coordinator.withdrawMGNandDepositsFromBothPools()')
+    await Promise.all(accounts.map(acc => coordinator.withdrawMGNandDepositsFromBothPools({ from: acc })))
+    return
+  }
+
+  console.log('Calling Pool.withdrawDeposit() and Pool.withdrawMagnolia() on each pool')
   await Promise.all(accounts.map(acc => Promise.all([
       ethPool.withdrawDeposit({ from: acc }),
       gnoPool.withdrawDeposit({ from: acc }),

--- a/trufflescripts/auction.js
+++ b/trufflescripts/auction.js
@@ -154,8 +154,10 @@ async function runStep(step, accounts, contracts, master) {
       await printPoolBalances(contracts)
       break
     case 9:
+      await printPoolBalances(contracts)
       await withdrawFunds(contracts, accounts)
       await printAccountBalances(contracts, accounts)
+      await printPoolBalances(contracts)
       break
 
     default:

--- a/trufflescripts/auction.js
+++ b/trufflescripts/auction.js
@@ -21,10 +21,10 @@
 
 /**
  * examples:
- * $ npx truffle exectruffle exec trufflescripts/auction.js
+ * $ npx truffle exec trufflescripts/auction.js
  * will go through the complete Pooling lifecycle
  * 
- * $ npx truffle exectruffle exec trufflescripts/auction.js 0 1 2
+ * $ npx truffle exec trufflescripts/auction.js 0 1 2
  * accounts are funded, auction started, deposits to pools made, State == Pooling
  *
  */

--- a/trufflescripts/auction.js
+++ b/trufflescripts/auction.js
@@ -165,7 +165,7 @@ async function runStep(step, accounts, contracts, master) {
 }
 
 async function fundAccounts(accounts, { ethToken, ethPool, dx, gnoPool, gnoToken }, master) {
-  console.log(`Funding accounts and approving token transfer to contracts`)
+  console.log('\nFunding accounts and approving token transfer to contracts')
 
   const amount = fundAmount
   // console.log('amount: ', amount)
@@ -196,7 +196,7 @@ async function fundAccounts(accounts, { ethToken, ethPool, dx, gnoPool, gnoToken
 }
 
 async function createAuction({ dx, ethToken, gnoToken }) {
-  console.log("Creating Auction")
+  console.log('\nCreating Auction')
 
   await dx.deposit(ethToken.address, toWei(1000))
   await dx.deposit(gnoToken.address, toWei(1000))
@@ -226,7 +226,7 @@ async function createAuction({ dx, ethToken, gnoToken }) {
 
 async function depositToPools({ ethPool, gnoPool, ethToken, gnoToken }, accounts) {
   const amount = depositAmount
-  console.log(`Depositing ${amount} WETH and GNO to EthPool and GnoPoll respectively from each account`)
+  console.log(`\nDepositing ${amount} WETH and GNO to EthPool and GnoPoll respectively from each account`)
 
   // console.log((await ethToken.balanceOf(accounts[0])).toString())
   // console.log((await ethToken.allowance(accounts[0], ethPool.address)).toString())
@@ -249,7 +249,7 @@ async function depositToPools({ ethPool, gnoPool, ethToken, gnoToken }, accounts
 
 async function participateInAuction({ dx, ethPool, ethToken, gnoToken, coordinator }) {
   const auctionIndex = await dx.getAuctionIndex.call(ethToken.address, gnoToken.address)
-  console.log(`Participating in WETH-GNO-${auctionIndex} auction`)
+  console.log(`\nParticipating in WETH-GNO-${auctionIndex} auction`)
   
   await printPoolState(ethPool)
 
@@ -264,7 +264,7 @@ async function participateInAuction({ dx, ethPool, ethToken, gnoToken, coordinat
 
 async function fillAndClearAuctions({ dx, ethPool, gnoPool, ethToken, gnoToken }, percentOfPreviousPrice, buyer) {
   const auctionIndex = await dx.getAuctionIndex(ethToken.address, gnoToken.address)
-  console.log(`Filling and clearing WETH-GNO-${auctionIndex} auction`)
+  console.log(`\nFilling and clearing WETH-GNO-${auctionIndex} auction`)
 
   await printPoolState(ethPool)
 
@@ -281,25 +281,25 @@ async function fillAndClearAuctions({ dx, ethPool, gnoPool, ethToken, gnoToken }
   await printAuctionPrice(dx, ethToken, gnoToken)
 
   await dx.postBuyOrder(ethToken.address, gnoToken.address, auctionIndex, toWei(10000))
-  console.log('BOUGHT 1')
+  console.log('BOUGHT WETH-GNO')
   await printAuctionPrice(dx, ethToken, gnoToken)
   await dx.postBuyOrder(gnoToken.address, ethToken.address, auctionIndex, toWei(10000))
-  console.log('BOUGHT 2')
+  console.log('BOUGHT GNO-WETH')
   await printAuctionPrice(dx, ethToken, gnoToken)
   await dx.claimBuyerFunds(ethToken.address, gnoToken.address, buyer, auctionIndex)
-  console.log('CLAIMED 1')
+  console.log('CLAIMED Buyer Funds in WETH-GNO')
   
   await printAuctionPrice(dx, ethToken, gnoToken)
   await dx.claimBuyerFunds(gnoToken.address, ethToken.address, buyer, auctionIndex)
-  console.log('CLAIMED 2')
+  console.log('CLAIMED Buyer Funds in GNO-WETH')
   
   await printAuctionPrice(dx, ethToken, gnoToken)
   await dx.claimSellerFunds(gnoToken.address, ethToken.address, buyer, auctionIndex)
-  console.log('CLAIMED 3')
+  console.log('CLAIMED SELLER Funds in WETH-GNO')
   
   await printAuctionPrice(dx, ethToken, gnoToken)
   await dx.claimSellerFunds(ethToken.address, gnoToken.address, buyer, auctionIndex)
-  console.log('CLAIMED 4')
+  console.log('CLAIMED Seller Funds in GNO-WETH')
   
 
   const newAuctionIndex = await dx.getAuctionIndex(ethToken.address, gnoToken.address)
@@ -346,7 +346,7 @@ function sumBnArray(bns) {
 }
 
 async function waitTillPoolingEnded({ ethPool }) {
-  console.log('Waiting until Pooling state ends')
+  console.log('\nWaiting until Pooling state ends')
 
   await printPoolState(ethPool)
 
@@ -361,7 +361,7 @@ async function waitTillPoolingEnded({ ethPool }) {
 
 
 async function triggerMGNunlockAndClaimTokens({ ethPool, gnoPool }) {
-  console.log('Triggering MGN unlock and claiming tokens')
+  console.log('\nTriggering MGN unlock and claiming tokens')
 
   await printPoolState(ethPool)
 
@@ -388,6 +388,7 @@ async function checkPoolingEnded(pool) {
 }
 
 async function printPoolBalances({ ethToken, gnoToken, mgnToken, ethPool, gnoPool }) {
+  console.group('\nPool Balances')
   const printBalances = async (pool) => {
     const ethBalance = await ethToken.balanceOf(pool.address)
     console.log('ETH: ', fromWei(ethBalance).toString())
@@ -408,9 +409,12 @@ async function printPoolBalances({ ethToken, gnoToken, mgnToken, ethPool, gnoPoo
   console.group('GnoPool:')
   await printBalances(gnoPool)
   console.groupEnd()
+
+  console.groupEnd()
 }
 
 async function printAccountBalances({ ethToken, gnoToken, mgnToken }, accounts) {
+  console.group('\nAccount Balances:')
   const balances = await Promise.all(accounts.map(acc => Promise.all([
       ethToken.balanceOf(acc),
       gnoToken.balanceOf(acc),
@@ -429,17 +433,19 @@ async function printAccountBalances({ ethToken, gnoToken, mgnToken }, accounts) 
     console.log('Will be unlocked MGN: ', fromWei(uMGN.amountUnlocked).toString())
     console.groupEnd()
   })
+
+  console.groupEnd()
 }
 
 async function waitTillwithdrawMGN({ ethPool }) {
-  console.log('Skipping 24h of lock period')
+  console.log('\nSkipping 24h of lock period')
   await increaseTimeBy(60 * 60 * 25)
 
   await printPoolState(ethPool)
 }
 
 async function withdrawUnlockedMagnolia({ ethPool, gnoPool }) {
-  console.log('Widthrawing Unlocked MGN')
+  console.log('\nWidthrawing Unlocked MGN')
 
   await printPoolState(ethPool)
   
@@ -529,23 +535,23 @@ async function printPoolState(pool) {
 async function printAuctionPrice(dx, ST, BT) {
   const ind = await dx.getAuctionIndex(ST.address, BT.address)
   const { num, den } = await dx.getCurrentAuctionPrice(ST.address, BT.address, ind)
-  const sellVol = await dx.sellVolumesCurrent(ST.address, BT.address)
-  const buyVol = await dx.buyVolumes(ST.address, BT.address)
+  // const sellVol = await dx.sellVolumesCurrent(ST.address, BT.address)
+  // const buyVol = await dx.buyVolumes(ST.address, BT.address)
   
   console.log('Auction index', ind.toNumber(), 'price:', [num, den].map(n => n.toString()))
-  console.log('sellVol: ', sellVol.toString())
-  console.log('buyVol: ', buyVol.toString())
+  // console.log('sellVol: ', sellVol.toString())
+  // console.log('buyVol: ', buyVol.toString())
 }
 
 async function waitUntilPriceIsXPercentOfPreviousPrice(dx, ST, BT, p) {
   const getAuctionStart = await dx.getAuctionStart.call(ST.address, BT.address)
   const startingTimeOfAuction = getAuctionStart.toNumber()
-  console.log('startingTimeOfAuction: ', startingTimeOfAuction)
+  // console.log('startingTimeOfAuction: ', startingTimeOfAuction)
   const timeToWaitFor = Math.ceil((86400 - p * 43200) / (1 + p)) + startingTimeOfAuction
   // wait until the price is good
   const incBy = timeToWaitFor - await getTime()
-  console.log('await getTime(): ', await getTime())
-  console.log('incBy: ', incBy)
+  // console.log('await getTime(): ', await getTime())
+  // console.log('incBy: ', incBy)
   if (incBy < 0) {
     return
   }


### PR DESCRIPTION
Withdrawing through coordinator doesn't withdraw everything:
small decimals of WETH and GNO stay in the pools
MGN isn't withdrawn at all

`npx truffle exec trufflescripts/auction.js --revert` at the end of the pooling produces:
```
...
    Account 0x1dF62f291b2E969fB0849d99D9Ce41e2F137006e
      ETH:  9900.039738296755507331
      GNO:  9900.039643445078847281
      MGN:  103.511891688853728643
      Locked MGN:  0
      Will be unlocked MGN:  0
  
  Pool Balances
    EthPool:
      ETH:  0.000000000000000003
      GNO:  0
      MGN:  0.000000000000000003
      Locked MGN:  0
      Will be unlocked MGN:  0
    GnoPool:
      ETH:  0
      GNO:  0.000000000000000003
      MGN:  0.000000000000000006
      Locked MGN:  0
      Will be unlocked MGN:  0
```

We can see that MGN from the pools was withdrawn into the accounts.
This was done with direct `pool.withdrawMagnolia()` calls

-----------------------------

`npx truffle exec trufflescripts/auction.js --revert -c` at the end of the pooling produces:
```
...
    Account 0x1dF62f291b2E969fB0849d99D9Ce41e2F137006e
      ETH:  9900
      GNO:  9900
      MGN:  0
      Locked MGN:  0
      Will be unlocked MGN:  0
  
  Pool Balances
    EthPool:
      ETH:  0.35764748559167673
      GNO:  0
      MGN:  895.85764748559167673
      Locked MGN:  0
      Will be unlocked MGN:  0
    GnoPool:
      ETH:  0
      GNO:  0.356931474609511211
      MGN:  35.749380528883991814
      Locked MGN:  0
      Will be unlocked MGN:  0
```
MGN stays in the pool when `Coordinator.withdraw...` is called


This PR only demonstrates the behaviour.